### PR TITLE
CI: Add cargo-audit step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,19 @@ rust:
 matrix:
     allow_failure:
         - rust: "nightly"
+    include:
+        - name: Run cargo audit
+          rust: stable
+          env: TASK=audit
     fast_finish: true
+
+install:
+    - cargo build --verbose
+    - if [ "$TASK" = "audit" ]; then cargo install cargo-audit; fi
+
+script:
+    - if [ "$TASK" = "audit" ]; then
+          cargo audit;
+      else
+          cargo test --verbose;
+      fi


### PR DESCRIPTION
It checks for known vulnerabilities in the dependencies.

I would also recommend setting up a Travis [cron job](https://docs.travis-ci.com/user/cron-jobs/) to run the CI every week.