### PR TITLE
`Make install` now work with the busybox toolchain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+## Fixed
+- `make install` now work with the busybox toolchain.
+
 ## [0.7.0] - 2020-03-12
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,15 @@ update:
 	cargo update
 
 install:
-	install -D --mode=0755 $(TARGET_DIR)/acmed $(DESTDIR)$(BINDIR)/acmed
-	install -D --mode=0755 $(TARGET_DIR)/tacd $(DESTDIR)$(BINDIR)/tacd
-	install -D --mode=0644 $(TARGET_DIR)/man/acmed.8.gz $(DESTDIR)$(DATADIR)/man/man8/acmed.8.gz
-	install -D --mode=0644 $(TARGET_DIR)/man/acmed.toml.5.gz $(DESTDIR)$(DATADIR)/man/man5/acmed.toml.5.gz
-	install -D --mode=0644 $(TARGET_DIR)/man/tacd.8.gz $(DESTDIR)$(DATADIR)/man/man8/tacd.8.gz
-	install -D --mode=0644 acmed/config/acmed.toml $(DESTDIR)$(SYSCONFDIR)/acmed/acmed.toml
-	install -D --mode=0644 acmed/config/default_hooks.toml $(DESTDIR)$(SYSCONFDIR)/acmed/default_hooks.toml
-	install -d --mode=0700 $(DESTDIR)$(SYSCONFDIR)/acmed/accounts
-	install -d --mode=0755 $(DESTDIR)$(SYSCONFDIR)/acmed/certs
+	install -D -m 0755 $(TARGET_DIR)/acmed $(DESTDIR)$(BINDIR)/acmed
+	install -D -m 0755 $(TARGET_DIR)/tacd $(DESTDIR)$(BINDIR)/tacd
+	install -D -m 0644 $(TARGET_DIR)/man/acmed.8.gz $(DESTDIR)$(DATADIR)/man/man8/acmed.8.gz
+	install -D -m 0644 $(TARGET_DIR)/man/acmed.toml.5.gz $(DESTDIR)$(DATADIR)/man/man5/acmed.toml.5.gz
+	install -D -m 0644 $(TARGET_DIR)/man/tacd.8.gz $(DESTDIR)$(DATADIR)/man/man8/tacd.8.gz
+	install -D -m 0644 acmed/config/acmed.toml $(DESTDIR)$(SYSCONFDIR)/acmed/acmed.toml
+	install -D -m 0644 acmed/config/default_hooks.toml $(DESTDIR)$(SYSCONFDIR)/acmed/default_hooks.toml
+	install -d -m 0700 $(DESTDIR)$(SYSCONFDIR)/acmed/accounts
+	install -d -m 0755 $(DESTDIR)$(SYSCONFDIR)/acmed/certs
 
 clean:
 	cargo clean


### PR DESCRIPTION
Hello,

The original _Makefile_ doesn't work on [Alpine Linux](https://alpinelinux.org/).
The OS use [Busybox](https://busybox.net/) and his `install` command doesn't understand `--mode` option, we need to use `-m` instead.

This is Fixed in this PR.