### PR TITLE
Log certificate domains before and after renewal

### DIFF
--- a/acmed/src/acme_proto.rs
+++ b/acmed/src/acme_proto.rs
@@ -210,6 +210,6 @@ pub fn request_certificate(cert: &Certificate, root_certs: &[String]) -> Result<
     let (crt, _) = http::get_certificate(cert, root_certs, &crt_url, &data_builder, &nonce)?;
     storage::write_certificate(cert, &crt.as_bytes())?;
 
-    cert.info("Certificate renewed");
+    cert.info(&format!("Certificate renewed (domains: {})", cert.domain_list()));
     Ok(())
 }

--- a/acmed/src/acme_proto/account.rs
+++ b/acmed/src/acme_proto/account.rs
@@ -50,13 +50,11 @@ pub fn init_account(cert: &Certificate) -> Result<(), Error> {
         let sign_alg = SignatureAlgorithm::from_str(crate::DEFAULT_JWS_SIGN_ALGO)?;
         let key_pair = sign_alg.gen_key_pair()?;
         storage::set_account_keypair(cert, &key_pair)?;
-        let msg = format!("Account {} created.", &cert.account.name);
-        cert.info(&msg)
+        cert.info(&format!("Account {} created", &cert.account.name));
     } else {
         // TODO: check if the keys are suitable for the specified signature algorithm
         // and, if not, initiate a key rollover.
-        let msg = format!("Account {} already exists.", &cert.account.name);
-        cert.debug(&msg)
+        cert.debug(&format!("Account {} already exists", &cert.account.name));
     }
     Ok(())
 }

--- a/acmed/src/certificate.rs
+++ b/acmed/src/certificate.rs
@@ -105,7 +105,7 @@ impl Certificate {
 
     fn is_expiring(&self, cert: &X509Certificate) -> Result<bool, Error> {
         let expires_in = cert.expires_in()?;
-        self.debug(&format!("expires in {} days", expires_in.as_secs() / 86400));
+        self.debug(&format!("Certificate expires in {} days", expires_in.as_secs() / 86400));
         // TODO: allow a custom duration (using time-parse ?)
         // 1814400 is 3 weeks (3 * 7 * 24 * 60 * 60)
         let renewal_time = Duration::new(1_814_400, 0);
@@ -134,7 +134,17 @@ impl Certificate {
         has_miss
     }
 
+    /// Return a comma-separated list of the domains this certificate is valid for.
+    pub fn domain_list(&self) -> String {
+        self.domains
+            .iter()
+            .map(|domain| &*domain.dns)
+            .collect::<Vec<&str>>()
+            .join(",")
+    }
+
     pub fn should_renew(&self) -> Result<bool, Error> {
+        self.debug(&format!("Checking for renewal (domains: {})", self.domain_list()));
         if !certificate_files_exists(&self) {
             self.debug("certificate does not exist: requesting one");
             return Ok(true);

--- a/acmed/src/certificate.rs
+++ b/acmed/src/certificate.rs
@@ -155,9 +155,9 @@ impl Certificate {
         let renew = renew || self.is_expiring(&cert)?;
 
         if renew {
-            self.debug("The certificate will be renewed now.");
+            self.debug("The certificate will be renewed now");
         } else {
-            self.debug("The certificate will not be renewed now.");
+            self.debug("The certificate will not be renewed now");
         }
         Ok(renew)
     }


### PR DESCRIPTION
Right now only the id is logged as a prefix (e.g. crt-3), so it's not possible to easily determine *which* certificate was renewed, or failed to renew.

New loogs look like this:

```
[2020-05-28T23:23:28Z DEBUG acmed::certificate] crt-2: Checking for renewal (domains: acmed-test.dbrgn.ch,acmed-test2.dbrgn.ch)
[2020-05-28T23:23:28Z DEBUG acmed::certificate] crt-2: Certificate expires in 89 days
[2020-05-28T23:23:28Z DEBUG acmed::certificate] crt-2: The certificate will not be renewed now
```

...or

```
[2020-05-28T23:23:12Z INFO  acmed::certificate] crt-1: Certificate renewed (domains: acmed-test.dbrgn.ch,acmed-test2.dbrgn.ch)
```