### PR TITLE
Add example systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ Running ACMEd as root is the simplest configuration since you do not have to wor
 
 However, if you are concerned with safety, you should create a dedicated user for ACMEd. Before doing so, please consider the following points: "Will your services be able to read both the private key and the certificate?" and "Will the ACMEd user be able to execute the hooks?". The later could be achieved using sudo or Polkit.
 
-
 ### Why is there no option to run ACMEd as a specific user or group?
 
 The reason some services has such an option is because at startup they may have to load data only accessible by root, hence they have to change the user themselves after those data are loaded. For example, this is wildly used in web servers so they load a private key, which should only be accessible by root. Since ACMEd does not have such requirement, it should be run directly as the correct user.
+
+### How can I run ACMEd with systemd?
+
+An example service file is provided (see `acmed.service.example`). The file might need adjustments in order to work on your system (e.g. binary path, user, group, directories...), but it's probably a good starting point.
 
 ### Is it suitable for beginners?
 

--- a/acmed.service.example
+++ b/acmed.service.example
@@ -1,0 +1,29 @@
+# systemd example unit file. Please adjust.
+
+[Unit]
+Description=ACME client daemon
+After=network.target
+
+[Service]
+User=acmed
+Group=acmed
+
+# Working directory
+WorkingDirectory=/etc/acmed
+
+# Starting, stopping, timeouts
+ExecStart=/usr/local/bin/acmed --foreground --pid-file /etc/acmed/acmed.pid --log-level debug --log-stderr
+TimeoutStartSec=3
+TimeoutStopSec=5
+Restart=on-failure
+KillSignal=SIGINT
+
+# Sandboxing, reduce privileges, only allow write access to working directory
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectSystem=strict
+ReadWritePaths=/etc/acmed/
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This might be useful to some users. It also includes some sandboxing options for increased security, e.g. mounting the entire file system as read-only except for the `/etc/acmed/` directory.

If you don't think this should be added, feel free to close the PR. However, it might benefit people that want to package acmed for a distro (as a starting point).