### PR TITLE
Move LE endpoints to separate config file

### DIFF
--- a/acmed/config/acmed.toml
+++ b/acmed/config/acmed.toml
@@ -1,20 +1,4 @@
 include = [
-    "default_hooks.toml"
+    "default_hooks.toml",
+    "letsencrypt.toml",
 ]
-
-[[rate-limit]]
-name = "LE min"
-number = 20
-period = "1s"
-
-[[endpoint]]
-name = "letsencrypt v2 prod"
-url = "https://acme-v02.api.letsencrypt.org/directory"
-rate_limits = ["LE min"]
-tos_agreed = false
-
-[[endpoint]]
-name = "letsencrypt v2 staging"
-url = "https://acme-staging-v02.api.letsencrypt.org/directory"
-rate_limits = ["LE min"]
-tos_agreed = false

--- a/acmed/config/letsencrypt.toml
+++ b/acmed/config/letsencrypt.toml
@@ -1,0 +1,16 @@
+[[rate-limit]]
+name = "LE min"
+number = 20
+period = "1s"
+
+[[endpoint]]
+name = "letsencrypt v2 prod"
+url = "https://acme-v02.api.letsencrypt.org/directory"
+rate_limits = ["LE min"]
+tos_agreed = false
+
+[[endpoint]]
+name = "letsencrypt v2 staging"
+url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+rate_limits = ["LE min"]
+tos_agreed = false


### PR DESCRIPTION
I like to try and avoid copying vendor configs as much as possible, and so I think it would be useful to have the letsencrypt endpoint definitions in a file that can be included instead. That way, if you want to have a custom `acmed.toml` you don't need to copy those definitions.