### PR TITLE
Draft: nginx hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ install:
 	    install -m 0644 $(TARGET_DIR)/man/acmed.toml.5.gz $(DESTDIR)$(MAN5DIR)/acmed.toml.5.gz; \
 	    install -m 0644 acmed/config/acmed.toml $(DESTDIR)$(SYSCONFDIR)/acmed/acmed.toml; \
 	    install -m 0644 acmed/config/default_hooks.toml $(DESTDIR)$(SYSCONFDIR)/acmed/default_hooks.toml; \
+	    install -m 0644 acmed/config/nginx_hooks.toml $(DESTDIR)$(SYSCONFDIR)/acmed/nginx_hooks.toml; \
 	    install -m 0644 acmed/config/letsencrypt.toml $(DESTDIR)$(SYSCONFDIR)/acmed/letsencrypt.toml; \
 	fi
 	if test -f "$(TARGET_DIR)/tacd"; then \

--- a/acmed/config/acmed.toml
+++ b/acmed/config/acmed.toml
@@ -5,5 +5,6 @@
 
 include = [
     "default_hooks.toml",
+    "nginx_hooks.toml",
     "letsencrypt.toml",
 ]

--- a/acmed/config/nginx_hooks.toml
+++ b/acmed/config/nginx_hooks.toml
@@ -1,0 +1,130 @@
+# Copyright (c) 2021 Rodolphe Bréard <rodolphe@breard.tf>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# ------------------------------------------------------------------------
+# ACMEd hooks adapting nginx configuration
+# You should not edit this file since it may be overridden by a newer one.
+# ------------------------------------------------------------------------
+
+
+###
+# nginx file storing challenge root in "/etc/nginx/conf.d/{{challenge-location}}/"
+# env: NGINX_CONFDIR -> /etc/nginx/conf.d
+# env: NGINX_CHALLENGE_LOCTION -> 001-challenge-letsencrypt.conf
+###
+
+[[hook]]
+name = "nginx-config-challenge-location-chmod"
+type = ["challenge-http-01", "post-operation"]
+cmd = "chmod"
+args = [
+    "ug+rw",
+    "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_CHALLENGE_LOCATION}}{{env.NGINX_CHALLENGE_LOCATION}}{{else}}001-challenge-letsencrypt.conf{{/if}}"
+]
+allow_failure = true
+
+[[hook]]
+name = "nginx-config-challenge-location-create"
+type = ["challenge-http-01", "post-operation"]
+cmd = "cat"
+args = [ "-" ]
+stdin_str = """###
+# Let's Encrypt: acme-challenge location
+###
+
+location ^~ /.well-known/acme-challenge/ {
+  allow all;
+  root "{{#if env.HTTP_ROOT}}{{env.HTTP_ROOT}}{{else}}/var/lib/acmed/domains{{/if}}";
+  default_type "text/plain";
+  try_files $uri =404;
+}
+"""
+stdout = "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_CHALLENGE_LOCATION}}{{env.NGINX_CHALLENGE_LOCATION}}{{else}}001-challenge-letsencrypt.conf{{/if}}"
+
+[[hook]]
+name = "nginx-config-challenge-location-echo"
+type = ["challenge-http-01", "post-operation"]
+cmd = "echo"
+args = [
+    "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_CHALLENGE_LOCATION}}{{env.NGINX_CHALLENGE_LOCATION}}{{else}}001-challenge-letsencrypt.conf{{/if}}"
+]
+allow_failure = true
+
+[[group]]
+name = "nginx-config-challenge-location"
+# hook execution in order of definition
+hooks = [
+    "nginx-config-challenge-location-create",
+    "nginx-config-challenge-location-echo",
+    "nginx-config-challenge-location-chmod"
+]
+
+###
+# nginx reference to TLS certificates
+# env NGINX_TLS_CERTIFICATE -> 002-tls-certificates.conf
+# global: {{certificates_directory}}
+# certificate: {{name}}_{{key_type}}.{{file_type}}.{{ext}}
+###
+
+[[hook]]
+name = "nginx-config-certificate-location-chmod"
+type = ["challenge-http-01", "post-operation"]
+cmd = "chmod"
+args = [
+    "ug+rw",
+    "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_TLS_CERTIFICATE}}{{env.NGINX_TLS_CERTIFICATE}}{{else}}002-tls-certificates.conf{{/if}}"
+]
+allow_failure = true
+
+[[hook]]
+name = "nginx-config-certificate-location-create"
+type = ["challenge-http-01", "post-operation"]
+cmd = "cat"
+args = [ "-" ]
+## TODO
+# make following handlebars accessible in post-operation
+# ssl_certificate {{certificates_directory}}/{{name}}_{{key_type}}.crt.{{ext}};
+# ssl_certificate_key {{certificates_directory}}/{{name}}_{{key_type}}.pk.{{ext}};
+# workaround: define a env:ACMED_CERTS pointing to {{certificates_directory}}
+##
+stdin_str = """###
+# Let's Encrypt TLS certificats
+###
+
+ssl_certificate {{#if env.ACMED_CERTS}}{{env.ACMED_CERTS}}{{else}}/var/lib/acmed/certs{{/if}}/{{identifiers.[0]}}_{{key_type}}.crt.pem; # managed by ACMEd
+ssl_certificate_key {{#if env.ACMED_CERTS}}{{env.ACMED_CERTS}}{{else}}/var/lib/acmed/certs{{/if}}/{{identifiers.[0]}}_{{key_type}}.pk.pem; # managed by ACMEd
+
+ssl_session_cache shared:le_nginx_SSL:10m;
+ssl_session_timeout 1440m;
+ssl_session_tickets off;
+
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers off;
+
+ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-PO
+LY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+"""
+stdout = "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_TLS_CERTIFICATE}}{{env.NGINX_TLS_CERTIFICATE}}{{else}}002-tls-certificates.conf{{/if}}"
+allow_failure = true
+
+[[hook]]
+name = "nginx-config-certificate-location-echo"
+type = ["challenge-http-01", "post-operation"]
+cmd = "echo"
+args = [
+    "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_TLS_CERTIFICATE}}{{env.NGINX_TLS_CERTIFICATE}}{{else}}002-tls-certificates.conf{{/if}}"
+]
+allow_failure = true
+
+[[group]]
+name = "nginx-config-certificate-location"
+# hook execution in order of definition
+hooks = [
+    "nginx-config-certificate-location-create",
+    "nginx-config-certificate-location-echo",
+    "nginx-config-certificate-location-chmod"
+]

--- a/acmed/config/nginx_hooks.toml
+++ b/acmed/config/nginx_hooks.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Rodolphe Bréard <rodolphe@breard.tf>
+# Copyright (c) 2021 Ralf Zerres <ralf.zerres@networkx.de>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -105,8 +105,7 @@ ssl_session_tickets off;
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_prefer_server_ciphers off;
 
-ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-PO
-LY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+ssl_ciphers 'HIGH:!eNULL:!LOW:!MEDIUM:!EXP:!RC4:!3DES:!MD5:!SHA1:!SHA256:!SHA384:!PSK:!kRSA:!SRP:-DH:+ECDH';
 """
 stdout = "{{#if env.NGINX_CONFDIR}}{{env.NGINX_CONFDIR}}{{else}}/etc/nginx/conf.d{{/if}}/{{#if env.NGINX_TLS_CERTIFICATE}}{{env.NGINX_TLS_CERTIFICATE}}{{else}}002-tls-certificates.conf{{/if}}"
 allow_failure = true

--- a/contrib/tmpfiles.d/acmed.conf
+++ b/contrib/tmpfiles.d/acmed.conf
@@ -1,0 +1,14 @@
+####
+# acmed:
+# running as sandboxed daemon (UID/GID) needs Read/Write access
+# preset runtime environment, if not restricted via systemd unit
+###
+
+#Type Path                               Mode User  Group Age Argument
+d     /run/acmed                         0755 acmed acmed -   -
+f     /run/acmed/acmed.pid               0644 acmed acmed -   -
+
+d     /var/lib/acmed                     0755 acmed acmed -   -
+d     /var/lib/acmed/accounts            0700 acmed acmed -   -
+d     /var/lib/acmed/certs               0755 acmed acmed -   -
+d     /var/lib/acmed/domains             0755 acmed acmed -   -


### PR DESCRIPTION
# Background
When using ACME challenge type 'http-01', the agent protocol needs to store and exchange a `nounce` (that the agent must sign with its private key pair) to prove control of the domain. 
The CA creates a file (including the encrypted nounce), that needs to be transfered into a writable challange location (e.g. `http://<your-domain>/.well-known/acme-challenge/) of the requesting domain. This storage location needs to be preset/defined inside the referenced webserver config , before the challenge request is negociated via ACMEd.

ACMEd's API is offering `hooks`, that can be used to create template files. The contents of the one template file will store the location of the challange location. The other file will store the name and location of the created certificate and its corresponding key.
Both files will be included inside the webserver configuration file. 
When using `nginx` as a webserver, we can take advantage of the `include` statement. This statement enables the web-administration to include the contents of the referenced template file at point inside the [virtual-] host configuration file (default: $NGINX_CONFDIR -> `/etc/nginx/conf.d`) .

## Shortcummings

* The running ACMEd instance needs `ReadWrite` access to $NGINX_CONFDIR.
* We like to run as a sandboxed dedicated system user (e.g `acmed`).
* It's uid/gid probably isn't authorized to write $NGINX_CONFDIR nor the other webserver config files.  

A possible solution for this dilemma is a system process, that is able to change the files before the ACMEd proccess is launched. `systemd` managed systems offer the `systemd-tmpfiles` binary. It is accompanied with `tmpfiles-units` (e.g. /usr/lib/tmpfiles.d/acmed.conf), that administrators can adjust and preset needed directories and their access rights. With this adjustments the ACMEd' process is allowed to wite to `$NGINX_CONFDIR` and programaticaly adapt the intended configuration. 

# Proposal Version 1
## Hook structure
Via dedicated hooks  the  ACMEd's API will create two templates files:

  * `challange-location`
  * `certificate-location`

Both names will be constructed wile resolving the enviroment variables

 * NGINX_CHALLENGE_LOCTION -> default: 001-challenge-letsencrypt.conf
 * NGINX_TLS_CERTIFICATE -> default: 002-tls-certificates.conf

Within the API, the hooks are addressed using their group names

 * `nginx-config-challenge-location`
    this will generate -> $NGINX_CONFDIR/$NGINX_CHALLENGE_LOCATION
 * `nginx-config-certificate-location`
    this will generate -> $NGINX_CONFDIR/$NGINX_TLS_CERTIFICATE

## Creation of the templates
The resulting files will be stored inside the target filesystem. Again we can use a resolvable environment variable:

 * NGINX_CONFDIR -> default: /etc/nginx/conf.d

## Consuming the templates
Finally, a website admin (or an authorized process) needs to include

   * $NGINX_CHALLENGE_LOCATION and
   * $NGINX_TLS_CERTIFICATE

inside the  [virtual-]host configuration block of the website in question.


