### PR TITLE
pad ECDSA public key coordinates with zeros

### DIFF
--- a/acme_common/src/crypto/openssl_keys.rs
+++ b/acme_common/src/crypto/openssl_keys.rs
@@ -197,10 +197,10 @@ impl KeyPair {
     }
 
     fn get_ecdsa_jwk(&self, thumbprint: bool) -> Result<Value, Error> {
-        let (crv, alg, curve) = match self.key_type {
-            KeyType::EcdsaP256 => ("P-256", "ES256", Nid::X9_62_PRIME256V1),
-            KeyType::EcdsaP384 => ("P-384", "ES384", Nid::SECP384R1),
-            KeyType::EcdsaP521 => ("P-521", "ES512", Nid::SECP521R1),
+        let (crv, alg, size, curve) = match self.key_type {
+            KeyType::EcdsaP256 => ("P-256", "ES256", 32, Nid::X9_62_PRIME256V1),
+            KeyType::EcdsaP384 => ("P-384", "ES384", 48, Nid::SECP384R1),
+            KeyType::EcdsaP521 => ("P-521", "ES512", 66, Nid::SECP521R1),
             _ => {
                 return Err("not an ECDSA elliptic curve".into());
             }
@@ -214,8 +214,8 @@ impl KeyPair {
             .unwrap()
             .public_key()
             .affine_coordinates_gfp(&group, &mut x, &mut y, &mut ctx)?;
-        let x = b64_encode(&x.to_vec());
-        let y = b64_encode(&y.to_vec());
+        let x = b64_encode(&x.to_vec_padded(size)?);
+        let y = b64_encode(&y.to_vec_padded(size)?);
         let jwk = if thumbprint {
             json!({
                 "crv": crv,


### PR DESCRIPTION
As per RFC 7518: https://www.rfc-editor.org/rfc/rfc7518#section-6.2.1.2
>   The "x" (x coordinate) parameter contains the x coordinate for the
   Elliptic Curve point.  It is represented as the base64url encoding of
   the octet string representation of the coordinate, as defined in
   [Section 2.3.5](https://www.rfc-editor.org/rfc/rfc7518#section-2.3.5) of [SEC1](https://www.rfc-editor.org/rfc/rfc7518#ref-SEC1) [SEC1].  The length of this octet string MUST
   be the full size of a coordinate for the curve specified in the "crv"
   parameter.  For example, if the value of "crv" is "P-521", the octet
   string must be 66 octets long.
